### PR TITLE
Minor fixes: str_random not in Laravel 6/7 by default; typo in table name in migration

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -15,8 +15,8 @@ $factory->define(App\User::class, function (Faker\Generator $faker) {
     return [
         'name' => $faker->name,
         'email' => $faker->safeEmail,
-        'password' => bcrypt(str_random(10)),
-        'remember_token' => str_random(10),
+        'password' => bcrypt(Str::random(10)),
+        'remember_token' => Str::random(10),
     ];
 });
 

--- a/database/migrations/2016_08_15_174511_create_posts_table.php
+++ b/database/migrations/2016_08_15_174511_create_posts_table.php
@@ -27,6 +27,6 @@ class CreatePostsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('pots');
+        Schema::drop('posts');
     }
 }


### PR DESCRIPTION
There are two minor fixes in this pull request:

1.  Replace str_random with Str::random
2.  Fix a typo in the posts table name in the create posts table migration